### PR TITLE
Update golangci-lint version to v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,33 +1,15 @@
+version: "2"
 run:
-  timeout: 5m
   allow-parallel-runners: true
-
-issues:
-  # don't skip warning about doc comments
-  # don't exclude the default set of lint
-  exclude-use-default: false
-  # restore some of the defaults
-  # (fill in the rest as needed)
-  exclude-rules:
-    - path: "api/*"
-      linters:
-        - lll
-    - path: "internal/*"
-      linters:
-        - dupl
-        - lll
 linters:
-  disable-all: true
+  default: none
   enable:
+    - copyloopvar
     - dupl
     - errcheck
-    - exportloopref
     - ginkgolinter
     - goconst
     - gocyclo
-    - gofmt
-    - goimports
-    - gosimple
     - govet
     - ineffassign
     - lll
@@ -36,12 +18,35 @@ linters:
     - prealloc
     - revive
     - staticcheck
-    - typecheck
     - unconvert
     - unparam
     - unused
-
-linters-settings:
-  revive:
+  settings:
+    revive:
+      rules:
+        - name: comment-spacings
+        - name: import-shadowing
+  exclusions:
+    generated: lax
     rules:
-      - name: comment-spacings
+      - linters:
+          - lll
+        path: api/*
+      - linters:
+          - dupl
+          - lll
+        path: internal/*
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ MODELS_SCHEMA = $(LOCALBIN)/models-schema
 KUSTOMIZE_VERSION ?= v5.6.0
 CONTROLLER_TOOLS_VERSION ?= v0.17.2
 ENVTEST_VERSION ?= release-0.20
-GOLANGCI_LINT_VERSION ?= v1.64.5
+GOLANGCI_LINT_VERSION ?= v2.1.6
 GINKGO_VERSION ?= v2.23.4
 CODE_GENERATOR_VERSION ?= v0.31.1
 MODELS_SCHEMA_VERSION ?= v1.31.1
@@ -156,7 +156,7 @@ $(ENVTEST): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
 .PHONY: ginkgo
 ginkgo: $(GINKGO) ## Download ginkgo locally if necessary.

--- a/api/v1/nodeimageset_types.go
+++ b/api/v1/nodeimageset_types.go
@@ -57,17 +57,17 @@ type NodeImageSetStatus struct {
 
 	// DesiredImages is the number of images that need to be downloaded.
 	// +optional
-	//+kubebuilder:default:=0
+	// +kubebuilder:default:=0
 	DesiredImages int `json:"desiredImages,omitempty"`
 
 	// AvailableImages is the number of images that have completed downloading.
 	// +optional
-	//+kubebuilder:default:=0
+	// +kubebuilder:default:=0
 	AvailableImages int `json:"availableImages,omitempty"`
 
 	// DownloadFailedImages is the number of images that failed to download.
 	// +optional
-	//+kubebuilder:default:=0
+	// +kubebuilder:default:=0
 	DownloadFailedImages int `json:"downloadFailedImages,omitempty"`
 }
 

--- a/internal/webhook/v1/webhook_suite_test.go
+++ b/internal/webhook/v1/webhook_suite_test.go
@@ -102,8 +102,7 @@ var _ = BeforeSuite(func() {
 		if err != nil {
 			return err
 		}
-		conn.Close()
-		return nil
+		return conn.Close()
 	}).Should(Succeed())
 
 })


### PR DESCRIPTION
This commit updates golangci-lint to v2. The configuration in golangci.yml is based on the [kubebuilder template](https://github.com/kubernetes-sigs/kubebuilder/blob/fd63e2b62dfe979e0be3389168d6166309b8b338/pkg/plugins/golang/v4/scaffolds/internal/templates/golangci.go#L26).
Additionally, this commit fixes code issues that were flagged by the updated linter.

