### PR TITLE
Fix nodeimagesets permissions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -16,7 +16,6 @@ rules:
   - ofen.cybozu.io
   resources:
   - imageprefetches
-  - nodeimagesets
   verbs:
   - create
   - delete
@@ -41,3 +40,16 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ofen.cybozu.io
+  resources:
+  - nodeimagesets
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/internal/controller/imageprefetch_controller.go
+++ b/internal/controller/imageprefetch_controller.go
@@ -45,7 +45,7 @@ type ImagePrefetchReconciler struct {
 // +kubebuilder:rbac:groups=ofen.cybozu.io,resources=imageprefetches,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ofen.cybozu.io,resources=imageprefetches/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=ofen.cybozu.io,resources=imageprefetches/finalizers,verbs=update
-// +kubebuilder:rbac:groups=ofen.cybozu.io,resources=nodeimagesets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=ofen.cybozu.io,resources=nodeimagesets,verbs=get;list;watch;create;update;patch;delete;deletecollection
 // +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch
 
 func (r *ImagePrefetchReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
Add missing deletecollection permission to enable DeleteAllOf function 
in the finalize method for proper NodeImageSet cleanup during 
ImagePrefetch deletion.