### PR TITLE
fix: prevent adding failed images to workqueue repeatedly

### DIFF
--- a/api/v1/nodeimageset_types.go
+++ b/api/v1/nodeimageset_types.go
@@ -84,10 +84,11 @@ type ContainerImageStatus struct {
 }
 
 const (
-	WaitingForImageDownload = "WaitingForImageDownload"
-	ImageDownloaded         = "ImageDownloaded"
-	ImageDownloadInProgress = "ImageDownloadInProgress"
-	ImageDownloadFailed     = "ImageDownloadFailed"
+	WaitingForImageDownload        = "WaitingForImageDownload"
+	ImageDownloaded                = "ImageDownloaded"
+	ImageDownloadInProgress        = "ImageDownloadInProgress"
+	ImageDownloadFailed            = "ImageDownloadFailed"
+	ImageDownloadTemporarilyFailed = "ImageDownloadTemporarilyFailed"
 )
 
 const (


### PR DESCRIPTION
In the current implementation, the NodeImageSet Controller adds a target image to the work queue if the image has not yet been pulled or if the pull has failed.

However, this caused a duplication issue. While the logic re-enqueues an image upon a pull failure, the NodeImageSet Controller was also adding the same failed image, resulting in duplicates in the work queue.

To resolve this, I'm changing the implementation to only add images that are pending a pull to the work queue.