### PR TITLE
Fix credential leakage in error messages

### DIFF
--- a/internal/imgmanager/secret.go
+++ b/internal/imgmanager/secret.go
@@ -80,12 +80,12 @@ func processDockerCfg(data []byte, tokens map[string]Credentials) error {
 func extractCredentials(registry, authString string, tokens map[string]Credentials) error {
 	data, err := base64.StdEncoding.DecodeString(authString)
 	if err != nil {
-		return fmt.Errorf("failed to decode auth %s: %w", authString, err)
+		return fmt.Errorf("failed to decode auth [redacted]: %w", err)
 	}
 
 	username, password, ok := strings.Cut(string(data), ":")
 	if !ok {
-		return fmt.Errorf("failed to find username and password in auth %s", authString)
+		return fmt.Errorf("failed to find username and password in auth [redacted]")
 	}
 
 	tokens[registry] = Credentials{

--- a/internal/imgmanager/secret_test.go
+++ b/internal/imgmanager/secret_test.go
@@ -418,12 +418,13 @@ func TestExtractCredentials(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name          string
-		registry      string
-		authString    string
-		initialTokens map[string]Credentials
-		expectedCreds map[string]Credentials
-		expectError   bool
+		name             string
+		registry         string
+		authString       string
+		initialTokens    map[string]Credentials
+		expectedCreds    map[string]Credentials
+		expectError      bool
+		forbiddenStrings []string
 	}{
 		{
 			name:          "valid auth",
@@ -465,12 +466,13 @@ func TestExtractCredentials(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:          "invalid base64",
-			registry:      "registry.example.com",
-			authString:    "invalid-base64!",
-			initialTokens: map[string]Credentials{},
-			expectedCreds: nil,
-			expectError:   true,
+			name:             "invalid base64",
+			registry:         "registry.example.com",
+			authString:       "invalid-base64!",
+			initialTokens:    map[string]Credentials{},
+			expectedCreds:    nil,
+			expectError:      true,
+			forbiddenStrings: []string{"invalid-base64!"},
 		},
 		{
 			name:          "no colon in auth",
@@ -479,6 +481,8 @@ func TestExtractCredentials(t *testing.T) {
 			initialTokens: map[string]Credentials{},
 			expectedCreds: nil,
 			expectError:   true,
+			// error must not leak the base64-encoded auth string or its decoded value
+			forbiddenStrings: []string{base64.StdEncoding.EncodeToString([]byte("nocolon")), "nocolon"},
 		},
 		{
 			name:       "add to existing tokens",
@@ -515,6 +519,9 @@ func TestExtractCredentials(t *testing.T) {
 			err := extractCredentials(tt.registry, tt.authString, tokens)
 			if tt.expectError {
 				require.Error(t, err)
+				for _, forbidden := range tt.forbiddenStrings {
+					require.NotContains(t, err.Error(), forbidden)
+				}
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tt.expectedCreds, tokens)


### PR DESCRIPTION
- `extractCredentials()` was embedding raw base64-encoded credentials (`user:password`) directly into error messages
- These errors were propagated into two cluster-wide readable locations: Kubernetes Events and the `status.images[].error` field of NodeImageSet CRDs

This PR replaced the `authString` interpolation with `[redacted]` in the two error format strings in `internal/imgmanager/secret.go`.